### PR TITLE
Support src.yaml with YamlLoader

### DIFF
--- a/lib/sources.js
+++ b/lib/sources.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const Err = require('@kartotherian/err');
 const checkType = require('@kartotherian/input-validator');
 const core = require('./core');
-const { XmlLoader } = require('@kartotherian/module-loader');
+const { XmlLoader, YamlLoader } = require('@kartotherian/module-loader');
 
 Promise.promisifyAll(fs);
 
@@ -165,6 +165,11 @@ function updateInfo(info, override, source, sourceId) {
  * @param {object} src.xmlLayers
  * @param {object} src.xmlExceptLayers
  * @param {object} src.xmlSetDataSource
+ * @param {object|string} src.yaml
+ * @param {object} src.yamlSetParams
+ * @param {object} src.yamlLayers
+ * @param {object} src.yamlExceptLayers
+ * @param {object} src.yamlSetDataSource
  * @param {object} src.setInfo
  * @param {object} src.overrideInfo
  * @param sourceId
@@ -223,6 +228,10 @@ Sources.prototype._loadSourceAsync = function _loadSourceAsync(src, sourceId) {
     if (src.xml) {
       const xmlLoader = new XmlLoader(src, self._resolveValue.bind(self), core.log);
       return xmlLoader.load(uri.protocol);
+    }
+    if (src.yaml) {
+      const yamlLoader = new YamlLoader(src, self._resolveValue.bind(self), core.log);
+      return yamlLoader.load(uri.protocol);
     }
     return uri;
   }).then(uri => core.loadSource(uri)).then((handler) => {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@kartotherian/err": "^0.0.3",
     "@kartotherian/input-validator": "^0.0.6",
-    "@kartotherian/module-loader": "^0.0.5",
+    "@kartotherian/module-loader": "^0.1.0",
     "bluebird": "^3.5.0",
     "js-yaml": "^3.8.2",
     "quadtile-index": "^0.0.6",


### PR DESCRIPTION
* Load `src.yaml` just like `src.xml` but with YamlLoader
* Bump dependency on module-loader to a version that includes YamlLoader